### PR TITLE
Clang fix

### DIFF
--- a/controller_interface/include/controller_interface/internal/robothw_interfaces.h
+++ b/controller_interface/include/controller_interface/internal/robothw_interfaces.h
@@ -56,7 +56,7 @@ inline std::string enumerateElements(const T&           val,
   const std::string sdp = suffix+delimiter+prefix;
   std::stringstream ss;
   ss << prefix;
-  std::copy(val.begin(), val.end(), std::ostream_iterator<class T::value_type>(ss, sdp.c_str()));
+  std::copy(val.begin(), val.end(), std::ostream_iterator<typename T::value_type>(ss, sdp.c_str()));
   ret = ss.str();
   if (!ret.empty()) {ret.erase(ret.size() - delimiter.size() - prefix.size());}
   return ret;


### PR DESCRIPTION
Switched from something that works only for gcc to something that works for gcc and clang. Original error is:

robothw_interfaces.h:60:68: error: typedef 'value_type' cannot be referenced with a class specifier.